### PR TITLE
Fix/upgrade d

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Run all D Tests
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Dub Tests
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-13]
+        dc: [dmd, ldc ]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install D compiler
+        uses: dlang-community/setup-dlang@v2
+        with:
+          compiler: ${{ matrix.dc }}
+
+      - name: Compile HDF5 (C)
+        run: make lib
+
+      - name: Compile d_hdf5 lib (D)
+        run: make dub
+
+      - name: Run tests
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dub.selections.json
 *.h5
 docs/
 *.a
+c_hdf5

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+all: examples
+
+# Variables
+BASEDIR=$(PWD)/c_hdf5
+HDF5_MAJOR=1
+HDF5_MINOR=8
+HDF5_RELEASE=23
+HDF5_VERSION=$(HDF5_MAJOR).$(HDF5_MINOR).$(HDF5_RELEASE)
+HDF5_ARCHIVE=hdf5-$(HDF5_VERSION).tar.gz
+HDF5_URL=https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-$(HDF5_MAJOR).$(HDF5_MINOR)/hdf5-$(HDF5_VERSION)/src/$(HDF5_ARCHIVE)
+
+# Default target
+all: examples
+
+# Step to create directories
+$(BASEDIR)/.dummy:
+	mkdir -p $(BASEDIR)
+	touch $(BASEDIR)/.dummy
+
+# download
+$(BASEDIR)/$(HDF5_ARCHIVE): $(BASEDIR)/.dummy
+	wget -q $(HDF5_URL) -O $(BASEDIR)/$(HDF5_ARCHIVE)
+	touch $(BASEDIR)/$(HDF5_ARCHIVE)
+
+download: $(BASEDIR)/$(HDF5_ARCHIVE)
+
+# configure, build, and install HDF5
+$(BASEDIR)/lib/libhdf5.a: $(BASEDIR)/$(HDF5_ARCHIVE)
+	cd $(BASEDIR) && mkdir -p build && cd build && \
+	tar -xvzf ../$(HDF5_ARCHIVE) --strip-components 1 && \
+	./configure --prefix=$(BASEDIR) --disable-shared && \
+	$(MAKE) && \
+	$(MAKE) install
+
+lib: $(BASEDIR)/lib/libhdf5.a
+
+# Clean up build directory
+clean:
+	rm -rf $(BASEDIR)
+
+.PHONY: all download lib clean dub examples
+
+dub: $(BASEDIR)/lib/libhdf5.a
+	dub build
+
+test: dub
+	dub test --verbose

--- a/dub.json
+++ b/dub.json
@@ -21,6 +21,5 @@
     ],
     "sourcePaths": ["hdf5"],
     "importPaths": ["."],
-    "libs": ["hdf5"],
-    "lflags": ["-L/usr/local/lib"]
+    "lflags" : [ "-L$PACKAGE_DIR/c_hdf5/lib", "-lhdf5" ],
 }

--- a/hdf5/c/h5ac.d
+++ b/hdf5/c/h5ac.d
@@ -22,7 +22,7 @@ struct H5AC_cache_config_t {
     hbool_t rpt_fcn_enabled;
     hbool_t open_trace_file;
     hbool_t close_trace_file;
-    char    trace_file_name[H5AC__MAX_TRACE_FILE_NAME_LEN + 1];
+    char    [H5AC__MAX_TRACE_FILE_NAME_LEN + 1]trace_file_name;
     hbool_t evictions_enabled;
     hbool_t set_initial_size;
     size_t  initial_size;

--- a/hdf5/c/h5d.d
+++ b/hdf5/c/h5d.d
@@ -90,7 +90,7 @@ herr_t  H5Diterate(void *buf, hid_t type_id, hid_t space_id,
 herr_t  H5Dvlen_reclaim(hid_t type_id, hid_t space_id, hid_t plist_id, void *buf);
 herr_t  H5Dvlen_get_buf_size(hid_t dataset_id, hid_t type_id, hid_t space_id, hsize_t *size);
 herr_t  H5Dfill(const void *fill, hid_t fill_type, void *buf, hid_t buf_type, hid_t space);
-herr_t  H5Dset_extent(hid_t dset_id, const hsize_t size[]);
+herr_t  H5Dset_extent(hid_t dset_id, const hsize_t[] size);
 herr_t  H5Dscatter(H5D_scatter_func_t op, void *op_data, hid_t type_id,
                    hid_t dst_space_id, void *dst_buf);
 herr_t  H5Dgather(hid_t src_space_id, const void *src_buf, hid_t type_id,

--- a/hdf5/c/h5fd.d
+++ b/hdf5/c/h5fd.d
@@ -129,7 +129,7 @@ struct H5FD_class_t {
     herr_t  function (H5FD_t *file, hid_t dxpl_id, hbool_t closing) truncate;
     herr_t  function (H5FD_t *file, ubyte *oid, uint lock_type, hbool_t last) lock;
     herr_t  function (H5FD_t *file, ubyte *oid, hbool_t last) unlock;
-    H5FD_mem_t fl_map[H5FD_mem_t.H5FD_MEM_NTYPES];
+    H5FD_mem_t[H5FD_mem_t.H5FD_MEM_NTYPES] fl_map;
 }
 
 struct H5FD_free_t {

--- a/hdf5/c/h5p.d
+++ b/hdf5/c/h5p.d
@@ -186,13 +186,13 @@ herr_t  H5Pget_attr_creation_order(hid_t plist_id, uint *crt_order_flags);
 herr_t  H5Pset_obj_track_times(hid_t plist_id, hbool_t track_times);
 herr_t  H5Pget_obj_track_times(hid_t plist_id, hbool_t *track_times);
 herr_t  H5Pmodify_filter(hid_t plist_id, H5Z_filter_t filter, uint flags, size_t cd_nelmts,
-                           const uint cd_values[]);
+                           const uint[] cd_values);
 herr_t  H5Pset_filter(hid_t plist_id, H5Z_filter_t filter, uint flags, size_t cd_nelmts,
-                        const uint c_values[]);
+                        const uint[] c_values);
 int     H5Pget_nfilters(hid_t plist_id);
 H5Z_filter_t    H5Pget_filter2(hid_t plist_id, uint filter, uint *flags, size_t *cd_nelmts,
-                                 uint cd_values[], size_t namelen, char name[], uint *filter_config);
-herr_t  H5Pget_filter_by_id2(hid_t plist_id, H5Z_filter_t id, uint *flags, uint cd_values[],
+                                 uint[] cd_values, size_t namelen, char[] name, uint *filter_config);
+herr_t  H5Pget_filter_by_id2(hid_t plist_id, H5Z_filter_t id, uint *flags, uint[] cd_values,
                                uint *filter_config);
 htri_t  H5Pall_filters_avail(hid_t plist_id);
 herr_t  H5Premove_filter(hid_t plist_id, H5Z_filter_t filter);
@@ -258,8 +258,8 @@ herr_t  H5Pget_core_write_tracking(hid_t fapl_id, hbool_t *is_enabled, size_t *p
 
 herr_t  H5Pset_layout(hid_t plist_id, H5D_layout_t layout);
 H5D_layout_t    H5Pget_layout(hid_t plist_id);
-herr_t  H5Pset_chunk(hid_t plist_id, int ndims, const hsize_t dim[]);
-int     H5Pget_chunk(hid_t plist_id, int max_ndims, hsize_t dim[]);
+herr_t  H5Pset_chunk(hid_t plist_id, int ndims, const hsize_t[] dim);
+int     H5Pget_chunk(hid_t plist_id, int max_ndims, hsize_t[] dim);
 herr_t  H5Pset_external(hid_t plist_id, const char *name, off_t offset, hsize_t size);
 int     H5Pget_external_count(hid_t plist_id);
 herr_t  H5Pget_external(hid_t plist_id, uint idx, size_t name_size, char *name, hsize_t *size);

--- a/hdf5/c/h5s.d
+++ b/hdf5/c/h5s.d
@@ -46,24 +46,24 @@ enum H5S_sel_type {
 extern (C) nothrow @nogc:
 
 hid_t   H5Screate(H5S_class_t type);
-hid_t   H5Screate_simple(int rank, const hsize_t dims[], const hsize_t maxdims[]);
-herr_t  H5Sset_extent_simple(hid_t space_id, int rank, const hsize_t dims[], const hsize_t max[]);
+hid_t   H5Screate_simple(int rank, const hsize_t[] dims, const hsize_t[] maxdims);
+herr_t  H5Sset_extent_simple(hid_t space_id, int rank, const hsize_t[] dims, const hsize_t[] max);
 hid_t   H5Scopy(hid_t space_id);
 herr_t  H5Sclose(hid_t space_id);
 herr_t  H5Sencode(hid_t obj_id, void *buf, size_t *nalloc);
 hid_t   H5Sdecode(const void *buf);
 hssize_t    H5Sget_simple_extent_npoints(hid_t space_id);
 int     H5Sget_simple_extent_ndims(hid_t space_id);
-int     H5Sget_simple_extent_dims(hid_t space_id, hsize_t dims[], hsize_t maxdims[]);
+int     H5Sget_simple_extent_dims(hid_t space_id, hsize_t[] dims, hsize_t[] maxdims);
 htri_t  H5Sis_simple(hid_t space_id);
 hssize_t    H5Sget_select_npoints(hid_t spaceid);
-herr_t  H5Sselect_hyperslab(hid_t space_id, H5S_seloper_t op, const hsize_t start[],
-                            const hsize_t _stride[], const hsize_t count[], const hsize_t _block[]);
+herr_t  H5Sselect_hyperslab(hid_t space_id, H5S_seloper_t op, const hsize_t[] start,
+                            const hsize_t[] _stride, const hsize_t[] count, const hsize_t[] _block);
 
 version (NEW_HYPERSLAB_API) {
-    hid_t   H5Scombine_hyperslab(hid_t space_id, H5S_seloper_t op, const hsize_t start[],
-                                 const hsize_t _stride[], const hsize_t count[],
-                                 const hsize_t _block[]);
+    hid_t   H5Scombine_hyperslab(hid_t space_id, H5S_seloper_t op, const hsize_t[] start,
+                                 const hsize_t[] _stride, const hsize_t[] count,
+                                 const hsize_t[] _block);
     herr_t  H5Sselect_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id);
     hid_t   H5Scombine_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id);
 }
@@ -80,9 +80,9 @@ htri_t  H5Sselect_valid(hid_t spaceid);
 hssize_t    H5Sget_select_hyper_nblocks(hid_t spaceid);
 hssize_t    H5Sget_select_elem_npoints(hid_t spaceid);
 herr_t  H5Sget_select_hyper_blocklist(hid_t spaceid, hsize_t startblock,
-    hsize_t numblocks, hsize_t buf[]);
+    hsize_t numblocks, hsize_t[] buf);
 herr_t  H5Sget_select_elem_pointlist(hid_t spaceid, hsize_t startpoint,
-    hsize_t numpoints, hsize_t buf[]);
-herr_t  H5Sget_select_bounds(hid_t spaceid, hsize_t start[],
-    hsize_t end[]);
+    hsize_t numpoints, hsize_t[] buf);
+herr_t  H5Sget_select_bounds(hid_t spaceid, hsize_t[] start,
+    hsize_t[] end);
 H5S_sel_type    H5Sget_select_type(hid_t spaceid);

--- a/hdf5/c/h5t.d
+++ b/hdf5/c/h5t.d
@@ -293,9 +293,9 @@ herr_t  H5Tenum_valueof(hid_t type, const char *name, void *value);
 
 hid_t   H5Tvlen_create(hid_t base_id);
 
-hid_t   H5Tarray_create2(hid_t base_id, uint ndims, const hsize_t dim[]);
+hid_t   H5Tarray_create2(hid_t base_id, uint ndims, const hsize_t[] dim);
 int     H5Tget_array_ndims(hid_t type_id);
-int     H5Tget_array_dims2(hid_t type_id, hsize_t dims[]);
+int     H5Tget_array_dims2(hid_t type_id, hsize_t[] dims);
 
 herr_t  H5Tset_tag(hid_t type, const char *tag);
 char   *H5Tget_tag(hid_t type);

--- a/hdf5/c/h5z.d
+++ b/hdf5/c/h5z.d
@@ -103,7 +103,7 @@ alias H5Z_filter_func_t    = H5Z_cb_return_t function (H5Z_filter_t filter, void
                                                        size_t buf_size, void* op_data);
 alias H5Z_can_apply_func_t = htri_t function (hid_t dcpl_id, hid_t type_id, hid_t space_id);
 alias H5Z_set_local_func_t = herr_t function (hid_t dcpl_id, hid_t type_id, hid_t space_id);
-alias H5Z_func_t           = size_t function (uint flags, size_t cd_nelmts, const uint cd_values[],
+alias H5Z_func_t           = size_t function (uint flags, size_t cd_nelmts, const uint[] cd_values,
                                               size_t nbytes, size_t *buf_size, void **buf);
 
 herr_t  H5Zregister(const void *cls);

--- a/hdf5/c/meta/wrap.d
+++ b/hdf5/c/meta/wrap.d
@@ -55,6 +55,8 @@ unittest {
 
 mixin template makeProperties(alias parent, string suffix, alias func = {}) {
     import std.string, std.typetuple, hdf5.meta;
+    import std.meta : Filter;
+
     static if (__traits(compiles, __traits(allMembers, parent)))
         mixin _makeProperties!(parent, suffix, func,
             Filter!(_variableSuffixMatches!(parent, suffix),__traits(allMembers, parent)));
@@ -126,6 +128,8 @@ mixin template wrapSymbols(alias parent, alias wrapper) {
 
 unittest {
     import std.exception : assertThrown, assertNotThrown;
+    import std.traits : ParameterTypeTuple;
+
     auto wrapper(alias func)(ParameterTypeTuple!(func) args)
     {
         static if (is(ReturnType!(func) == void))

--- a/hdf5/exception.d
+++ b/hdf5/exception.d
@@ -1,7 +1,7 @@
 module hdf5.exception;
 
 import std.traits       : ParameterTypeTuple, ReturnType, isIntegral, isSigned;
-import std.exception    : assertThrown, assertNotThrown, enforceEx;
+import std.exception    : assertThrown, assertNotThrown, enforce;
 import std.string       : fromStringz, format;
 import std.conv         : to;
 
@@ -160,11 +160,11 @@ public class H5Exception : Exception {
             super(msg, file, line, next);
         }
         this(H5ErrorStack stack, Throwable next = null) {
-            super(stack.to!string, next);
+            super(stack.toString, next);
             this.stack = stack;
         }
         this(H5ErrorStack stack, string file, size_t line, Throwable next = null) {
-            super(stack.to!string, file, line, next);
+            super(stack.toString, file, line, next);
             this.stack = stack;
         }
     }
@@ -235,7 +235,7 @@ unittest {
 public alias errorCheckH5(alias func) = errorCheck!(func, H5Exception.check);
 
 public void enforceH5(T, Args...)(T value, lazy string msg, Args args) {
-    enforceEx!H5Exception(value, msg.format(args));
+    enforce!H5Exception(value, msg.format(args));
 }
 
 unittest {

--- a/hdf5/file.d
+++ b/hdf5/file.d
@@ -399,7 +399,7 @@ unittest {
     assert(file.userblock == 512);
     file.createGroup("bar");
     auto f = File(filename, "r+b");
-    ubyte data[512];
+    ubyte[512] data;
     foreach (i, ref x; data)
         x = cast(ubyte) (i % 256);
     f.rawWrite(data);

--- a/hdf5/id.d
+++ b/hdf5/id.d
@@ -29,11 +29,11 @@ private struct H5IDRegistry {
         }
     }
 
-    bool opIn_r(in H5ID obj) const {
+    bool opBinaryRight(string op: "in")(in H5ID obj) const {
         return toAddr(obj) in this;
     }
 
-    bool opIn_r(size_t addr) const {
+    bool opBinaryRight(string op: "in")(size_t addr) const {
         return (addr in registry) !is null;
     }
 

--- a/hdf5/location.d
+++ b/hdf5/location.d
@@ -64,6 +64,8 @@ package abstract class H5Location : H5ID {
 
 // name, filename, flush, comment, fileno
 unittest {
+    import std.path: buildPath;
+
     auto filename = tempDir.buildPath("foo.h5");
     scope(exit) if (filename.exists) filename.remove();
     auto file = new H5File(filename);


### PR DESCRIPTION
Fixes some 
 - syntax changes
 - deprecated D syntax
 - missing imports
 - function name changes

Unit tests seem to compile and run with LDC2 1.39